### PR TITLE
Revert "smdk4412-qcom : fix GET_CURRENT_CALLS crashes"

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/smdk4x12QComRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/smdk4x12QComRIL.java
@@ -241,6 +241,9 @@ public class smdk4x12QComRIL extends RIL implements CommandsInterface {
             dc.isMT = (0 != p.readInt());
             dc.als = p.readInt();
             voiceSettings = p.readInt();
+            if (isGSM){
+                p.readInt();
+            }
             dc.isVoice = (0 == voiceSettings) ? false : true;
             dc.isVoicePrivacy = (0 != p.readInt());
             if (isGSM) {


### PR DESCRIPTION
Looks like it breaks devices that use prebuilt ril libs

This reverts commit b553455d58dabf2250a74ecd91a2faba60f5e843.

Change-Id: I9948080b8da620aa60280fc6496f7c2d89ba0aa2