### PR TITLE
smdk4x12QComRIL: Handle RIL_UNSOL_NITZ_TIME_RECEIVED

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/smdk4x12QComRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/smdk4x12QComRIL.java
@@ -150,6 +150,24 @@ public class smdk4x12QComRIL extends RIL implements CommandsInterface {
         return cardStatus;
     }
 
+    private void
+    fixNitz(Parcel p) {
+        int dataPosition = p.dataPosition();
+        String nitz = p.readString();
+        long nitzReceiveTime = p.readLong();
+
+        String[] nitzParts = nitz.split(",");
+        if (nitzParts.length >= 4) {
+            // 0=date, 1=time+zone, 2=dst, 3(+)=garbage that confuses ServiceStateTracker
+            nitz = nitzParts[0] + "," + nitzParts[1] + "," + nitzParts[2];
+            p.setDataPosition(dataPosition);
+            p.writeString(nitz);
+            p.writeLong(nitzReceiveTime);
+            // The string is shorter now, drop the extra bytes
+            p.setDataSize(p.dataPosition());
+        }
+    }
+
     @Override
     public void
     sendCdmaSms(byte[] pdu, Message result) {
@@ -305,6 +323,11 @@ public class smdk4x12QComRIL extends RIL implements CommandsInterface {
         int response = p.readInt();
 
         switch(response) {
+            case RIL_UNSOL_NITZ_TIME_RECEIVED:
+                fixNitz(p);
+                p.setDataPosition(dataPosition);
+                super.processUnsolicited(p, type);
+                break;
             case RIL_UNSOL_RIL_CONNECTED:
                 ret = responseInts(p);
                 setRadioPower(false, null);


### PR DESCRIPTION
* This fixes auto time zone
* This is related to how it was handled in the
  old SamsungQualcommRIL class (deprecated) but
  the Parcel is fixed rather than handling it
  directly in the RIL subclass
* This is done so that after we handle it,
  it's handled by processUnsolicited in the
  super class, which handles this UNSOL
* The extra "garbage" that is sent in the
  RIL_UNSOL_NITZ_TIME_RECEIVED parcel seems
  to be country MCC code for whatever reason

Change-Id: If4b2d206042fe7539e72a178fa1245b515720760